### PR TITLE
fix(ci): trigger CI on develop branch PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   lint:


### PR DESCRIPTION
Branch protection on develop requires Lint + Security Audit checks, but CI only triggered on PRs to main. This adds develop to the trigger branches so checks run correctly.

One-line change in ci.yml.