### PR TITLE
feat: raw_items collection pipeline (Phase 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,8 @@ ALLOWED_ORIGINS=localhost,127.0.0.1
 # Create at: Lark > Group > Settings > Bots > Add Bot > Custom Bot (Webhook)
 # Format: https://open.larksuite.com/open-apis/bot/v2/hook/<token>
 FEEDBACK_LARK_WEBHOOK=
+
+# Collector
+COLLECTOR_INTERVAL=300          # seconds between collection cycles (default: 300)
+COLLECTOR_CONCURRENCY=5         # max parallel source fetches (default: 5)
+DEFAULT_SOURCE_ID=              # source ID shown to non-logged-in users

--- a/migrations/010_raw_items.sql
+++ b/migrations/010_raw_items.sql
@@ -1,0 +1,20 @@
+-- raw_items table: intermediate storage between source fetch and digest generation
+CREATE TABLE IF NOT EXISTS raw_items (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source_id INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+  title TEXT NOT NULL DEFAULT '',
+  url TEXT NOT NULL DEFAULT '',
+  author TEXT DEFAULT '',
+  content TEXT NOT NULL DEFAULT '',
+  fetched_at TEXT NOT NULL DEFAULT (datetime('now')),
+  published_at TEXT,
+  dedup_key TEXT NOT NULL,
+  metadata TEXT DEFAULT '{}',
+  UNIQUE(source_id, dedup_key)
+);
+CREATE INDEX IF NOT EXISTS idx_raw_items_source_fetched ON raw_items(source_id, fetched_at DESC);
+CREATE INDEX IF NOT EXISTS idx_raw_items_fetched ON raw_items(fetched_at DESC);
+
+-- Error tracking columns for sources table
+ALTER TABLE sources ADD COLUMN fetch_error_count INTEGER DEFAULT 0;
+ALTER TABLE sources ADD COLUMN last_error TEXT;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "start": "node src/server.mjs",
     "dev": "node --watch src/server.mjs",
+    "collect": "node src/collector.mjs",
+    "collect:loop": "node src/collector.mjs --loop",
     "lint": "eslint src/",
     "test": "bash test/e2e.sh"
   },

--- a/src/collector.mjs
+++ b/src/collector.mjs
@@ -1,0 +1,422 @@
+/**
+ * ClawFeed Collector — fetches content from sources into raw_items.
+ *
+ * Usage:
+ *   node src/collector.mjs              # one-shot: fetch all due sources
+ *   node src/collector.mjs --loop       # continuous: run on interval
+ *   node src/collector.mjs --source 5   # fetch a single source by ID
+ */
+
+import http from 'http';
+import https from 'https';
+import { readFileSync, existsSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { lookup } from 'dns/promises';
+import { isIP } from 'net';
+import { getDb, getSourcesDueForFetch, getSource, insertRawItemsBatch, touchSourceFetch, recordSourceError, cleanOldRawItems } from './db.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+
+// Load .env
+const envPath = join(ROOT, '.env');
+const env = {};
+if (existsSync(envPath)) {
+  for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq > 0) env[trimmed.slice(0, eq)] = trimmed.slice(eq + 1);
+  }
+}
+
+const DB_PATH = process.env.DIGEST_DB || env.DIGEST_DB || join(ROOT, 'data', 'digest.db');
+mkdirSync(join(ROOT, 'data'), { recursive: true });
+const db = getDb(DB_PATH);
+
+const LOOP_INTERVAL = parseInt(env.COLLECTOR_INTERVAL || '300') * 1000;
+const CONCURRENCY = parseInt(env.COLLECTOR_CONCURRENCY || '5');
+const UA = 'ClawFeed-Collector/1.0';
+
+// ── SSRF protection ──
+
+function isPrivateOrSpecialIp(ip) {
+  if (!ip) return true;
+  if (ip.includes(':')) {
+    const n = ip.toLowerCase();
+    return n === '::1' || n.startsWith('fc') || n.startsWith('fd') || n.startsWith('fe80:') || n.startsWith('::ffff:127.');
+  }
+  const p = ip.split('.').map(Number);
+  if (p.length !== 4 || p.some((x) => Number.isNaN(x) || x < 0 || x > 255)) return true;
+  const [a, b] = p;
+  return a === 0 || a === 10 || a === 127 || (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168) || a >= 224;
+}
+
+async function assertSafeUrl(rawUrl) {
+  const u = new URL(rawUrl);
+  if (!['http:', 'https:'].includes(u.protocol)) throw new Error('invalid url scheme');
+  const host = u.hostname;
+  if (host === 'localhost' || host.endsWith('.localhost')) throw new Error('blocked host');
+  if (isIP(host) && isPrivateOrSpecialIp(host)) throw new Error('blocked host');
+  const resolved = await lookup(host, { all: true });
+  if (!resolved.length || resolved.some((r) => isPrivateOrSpecialIp(r.address))) {
+    throw new Error('blocked host');
+  }
+}
+
+// ── HTTP helper ──
+
+function httpGet(url, { timeout = 10000, maxBytes = 500000, redirectsLeft = 3 } = {}) {
+  return new Promise(async (resolve, reject) => {
+    try {
+      await assertSafeUrl(url);
+    } catch (e) {
+      return reject(e);
+    }
+    const mod = url.startsWith('https') ? https : http;
+    const r = mod.get(url, { headers: { 'User-Agent': UA, Accept: 'text/html,application/xhtml+xml,application/xml,application/json,*/*' } }, async (resp) => {
+      try {
+        if (resp.statusCode >= 300 && resp.statusCode < 400 && resp.headers.location) {
+          clearTimeout(timer);
+          if (redirectsLeft <= 0) return reject(new Error('too many redirects'));
+          const nextUrl = new URL(resp.headers.location, url).toString();
+          return resolve(await httpGet(nextUrl, { timeout: Math.max(2000, timeout - 2000), maxBytes, redirectsLeft: redirectsLeft - 1 }));
+        }
+        if (resp.statusCode >= 400) {
+          clearTimeout(timer);
+          return reject(new Error(`HTTP ${resp.statusCode}`));
+        }
+        let data = '';
+        let size = 0;
+        resp.on('data', c => { size += c.length; if (size > maxBytes) { resp.destroy(); } else { data += c; } });
+        resp.on('end', () => { clearTimeout(timer); resolve({ status: resp.statusCode, contentType: resp.headers['content-type'] || '', body: data }); });
+      } catch (e) { clearTimeout(timer); reject(e); }
+    });
+    const timer = setTimeout(() => { r.destroy(); reject(new Error('timeout')); }, timeout);
+    r.on('error', (e) => { clearTimeout(timer); reject(e); });
+  });
+}
+
+// ── Source fetchers ──
+
+function parseConfig(source) {
+  return typeof source.config === 'string' ? JSON.parse(source.config) : source.config;
+}
+
+async function fetchRss(source) {
+  const config = parseConfig(source);
+  const url = config.url;
+  if (!url) return [];
+
+  const resp = await httpGet(url);
+  const xml = resp.body;
+  const items = [];
+
+  const re = /<item[^>]*>([\s\S]*?)<\/item>|<entry[^>]*>([\s\S]*?)<\/entry>/gi;
+  let m;
+  while ((m = re.exec(xml)) && items.length < 50) {
+    const block = m[1] || m[2];
+    const title = extractXmlTag(block, 'title');
+    const link = extractXmlLink(block);
+    const author = extractXmlTag(block, 'author') || extractXmlTag(block, 'dc:creator') || '';
+    const description = extractXmlTag(block, 'description') || extractXmlTag(block, 'summary') || extractXmlTag(block, 'content') || '';
+    const pubDate = extractXmlTag(block, 'pubDate') || extractXmlTag(block, 'published') || extractXmlTag(block, 'updated') || '';
+
+    items.push({
+      title: stripCdata(title),
+      url: link,
+      author: stripCdata(author),
+      content: stripHtml(stripCdata(description)).slice(0, 2000),
+      publishedAt: pubDate ? normalizeDate(pubDate) : null,
+    });
+  }
+
+  return items;
+}
+
+async function fetchHackerNews(source) {
+  const config = parseConfig(source);
+  const filter = config.filter || 'top';
+  const minScore = config.min_score || 50;
+
+  const listUrl = `https://hacker-news.firebaseio.com/v0/${filter}stories.json`;
+  const resp = await httpGet(listUrl);
+  const ids = JSON.parse(resp.body).slice(0, 30);
+
+  // Fetch items with limited concurrency (5 at a time)
+  const items = [];
+  for (let i = 0; i < ids.length; i += 5) {
+    const batch = ids.slice(i, i + 5);
+    const results = await Promise.allSettled(
+      batch.map(async (id) => {
+        const itemResp = await httpGet(`https://hacker-news.firebaseio.com/v0/item/${id}.json`, { timeout: 5000 });
+        return JSON.parse(itemResp.body);
+      })
+    );
+    for (const r of results) {
+      if (r.status !== 'fulfilled' || !r.value) continue;
+      const item = r.value;
+      if (item.dead || item.deleted || item.score < minScore) continue;
+      items.push({
+        title: item.title || '',
+        url: item.url || `https://news.ycombinator.com/item?id=${item.id}`,
+        author: item.by || '',
+        content: item.title || '',
+        publishedAt: item.time ? new Date(item.time * 1000).toISOString() : null,
+        metadata: { score: item.score, comments: item.descendants || 0 },
+      });
+    }
+  }
+
+  return items;
+}
+
+async function fetchReddit(source) {
+  const config = parseConfig(source);
+  const subreddit = config.subreddit;
+  const sort = config.sort || 'hot';
+  const limit = Math.min(config.limit || 25, 50);
+
+  const url = `https://www.reddit.com/r/${encodeURIComponent(subreddit)}/${sort}.json?limit=${limit}&raw_json=1`;
+  const resp = await httpGet(url);
+  const data = JSON.parse(resp.body);
+
+  if (!data.data || !data.data.children) return [];
+
+  return data.data.children
+    .filter(c => c.kind === 't3' && !c.data.stickied)
+    .map(c => {
+      const d = c.data;
+      return {
+        title: d.title || '',
+        url: d.url || `https://www.reddit.com${d.permalink}`,
+        author: d.author || '',
+        content: (d.selftext || d.title || '').slice(0, 2000),
+        publishedAt: d.created_utc ? new Date(d.created_utc * 1000).toISOString() : null,
+        metadata: { score: d.score, comments: d.num_comments, subreddit: d.subreddit },
+      };
+    });
+}
+
+async function fetchGithubTrending(source) {
+  const config = parseConfig(source);
+  const language = config.language || '';
+  const since = config.since || 'daily';
+
+  const url = `https://github.com/trending${language && language !== 'all' ? '/' + encodeURIComponent(language) : ''}?since=${since}`;
+  const resp = await httpGet(url, { maxBytes: 1000000 });
+  const html = resp.body;
+
+  const items = [];
+  const repoRe = /<article[^>]*class="[^"]*Box-row[^"]*"[^>]*>([\s\S]*?)<\/article>/gi;
+  let m;
+  while ((m = repoRe.exec(html)) && items.length < 25) {
+    const block = m[1];
+    const hrefMatch = block.match(/href="(\/[^"]+?)"/);
+    if (!hrefMatch) continue;
+    const repoPath = hrefMatch[1].trim();
+    const repoUrl = `https://github.com${repoPath}`;
+    const repoName = repoPath.replace(/^\//, '');
+
+    const descMatch = block.match(/<p[^>]*>([\s\S]*?)<\/p>/);
+    const desc = descMatch ? stripHtml(descMatch[1]).trim() : '';
+
+    const starsMatch = block.match(/(\d[\d,]*)\s*stars?\s*today/i);
+    const starsToday = starsMatch ? parseInt(starsMatch[1].replace(/,/g, '')) : 0;
+
+    items.push({
+      title: repoName,
+      url: repoUrl,
+      content: desc,
+      publishedAt: null,
+      metadata: { stars_today: starsToday, language: language || 'all' },
+    });
+  }
+
+  return items;
+}
+
+async function fetchWebsite(source) {
+  const config = parseConfig(source);
+  const url = config.url;
+  if (!url) return [];
+
+  const resp = await httpGet(url, { maxBytes: 200000 });
+  const html = resp.body;
+
+  // Look for RSS link in HTML
+  const rssMatch = html.match(/<link[^>]*type=["']application\/(rss|atom)\+xml["'][^>]*href=["']([^"']+)["']/i);
+  if (rssMatch) {
+    const rssUrl = new URL(rssMatch[2], url).toString();
+    return fetchRss({ ...source, config: JSON.stringify({ url: rssUrl }) });
+  }
+
+  // Fallback: record page title + og:description as a single item
+  const titleMatch = html.match(/<title[^>]*>(.*?)<\/title>/is);
+  const title = titleMatch ? stripHtml(titleMatch[1]).trim() : url;
+  const ogDescMatch = html.match(/<meta[^>]*property=["']og:description["'][^>]*content=["']([^"']*?)["']/i);
+  const ogDesc = ogDescMatch ? ogDescMatch[1].trim() : '';
+
+  return [{
+    title,
+    url,
+    content: ogDesc || title,
+  }];
+}
+
+// Fetcher registry
+const FETCHERS = {
+  rss: fetchRss,
+  digest_feed: fetchRss,
+  hackernews: fetchHackerNews,
+  reddit: fetchReddit,
+  github_trending: fetchGithubTrending,
+  website: fetchWebsite,
+  // twitter_feed, twitter_list, twitter_bookmarks — Phase 1.5 (needs Twitter API)
+};
+
+// ── XML helpers ──
+
+function extractXmlTag(xml, tag) {
+  const re = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, 'i');
+  const m = xml.match(re);
+  return m ? m[1].trim() : '';
+}
+
+function extractXmlLink(xml) {
+  const hrefMatch = xml.match(/<link[^>]*href=["']([^"']+)["']/i);
+  if (hrefMatch) return hrefMatch[1].trim();
+  const contentMatch = xml.match(/<link[^>]*>(.*?)<\/link>/i);
+  if (contentMatch) return contentMatch[1].trim();
+  return '';
+}
+
+function stripCdata(s) {
+  return s.replace(/^<!\[CDATA\[/, '').replace(/\]\]>$/, '').trim();
+}
+
+function stripHtml(s) {
+  return s.replace(/<[^>]+>/g, ' ').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/\s+/g, ' ').trim();
+}
+
+function normalizeDate(s) {
+  try {
+    const d = new Date(s);
+    if (isNaN(d.getTime())) return null;
+    return d.toISOString();
+  } catch {
+    return null;
+  }
+}
+
+// ── Concurrency pool ──
+
+async function runWithConcurrency(tasks, limit) {
+  const results = [];
+  const executing = new Set();
+
+  for (const task of tasks) {
+    const p = task().then(
+      (result) => { executing.delete(p); return { ok: true, result }; },
+      (error) => { executing.delete(p); return { ok: false, error }; }
+    );
+    executing.add(p);
+    results.push(p);
+
+    if (executing.size >= limit) {
+      await Promise.race(executing);
+    }
+  }
+
+  return Promise.all(results);
+}
+
+// ── Main collection logic ──
+
+async function collectSource(source) {
+  const fetcher = FETCHERS[source.type];
+  if (!fetcher) {
+    return { sourceId: source.id, name: source.name, type: source.type, skipped: true, reason: `no fetcher for type '${source.type}'` };
+  }
+
+  try {
+    const items = await fetcher(source);
+    if (!items.length) {
+      touchSourceFetch(db, source.id);
+      return { sourceId: source.id, name: source.name, fetched: 0, inserted: 0 };
+    }
+
+    const inserted = insertRawItemsBatch(db, source.id, items);
+    touchSourceFetch(db, source.id);
+
+    return { sourceId: source.id, name: source.name, fetched: items.length, inserted };
+  } catch (e) {
+    recordSourceError(db, source.id, e.message);
+    return { sourceId: source.id, name: source.name, error: e.message };
+  }
+}
+
+async function collectAll() {
+  const sources = getSourcesDueForFetch(db);
+  if (!sources.length) {
+    console.log('[collector] No sources due for fetch');
+    return [];
+  }
+
+  console.log(`[collector] ${sources.length} source(s) due for fetch (concurrency: ${CONCURRENCY})`);
+
+  // Build task functions for concurrency pool
+  const tasks = sources.map((source) => () => collectSource(source));
+  const poolResults = await runWithConcurrency(tasks, CONCURRENCY);
+
+  const results = [];
+  for (let i = 0; i < sources.length; i++) {
+    const pr = poolResults[i];
+    const result = pr.ok ? pr.result : { sourceId: sources[i].id, name: sources[i].name, error: pr.error?.message || 'unknown error' };
+    results.push(result);
+
+    if (result.error) {
+      console.error(`[collector] ${result.name} (${sources[i].type}): ERROR ${result.error}`);
+    } else if (result.skipped) {
+      console.log(`[collector] ${result.name} (${sources[i].type}): skipped (${result.reason})`);
+    } else {
+      console.log(`[collector] ${result.name} (${sources[i].type}): fetched=${result.fetched} inserted=${result.inserted}`);
+    }
+  }
+
+  // Clean old items (30-day TTL)
+  const cleaned = cleanOldRawItems(db);
+  if (cleaned.changes > 0) {
+    console.log(`[collector] Cleaned ${cleaned.changes} old raw_items (>30 days)`);
+  }
+
+  return results;
+}
+
+// ── CLI ──
+
+const args = process.argv.slice(2);
+
+if (args.includes('--source')) {
+  const idx = args.indexOf('--source');
+  const sourceId = parseInt(args[idx + 1]);
+  const source = getSource(db, sourceId);
+  if (!source) {
+    console.error(`Source ${sourceId} not found`);
+    process.exit(1);
+  }
+  const result = await collectSource(source);
+  console.log(JSON.stringify(result, null, 2));
+} else if (args.includes('--loop')) {
+  console.log(`[collector] Starting loop (interval: ${LOOP_INTERVAL / 1000}s, concurrency: ${CONCURRENCY})`);
+  await collectAll();
+  setInterval(collectAll, LOOP_INTERVAL);
+} else {
+  const results = await collectAll();
+  console.log(`\n[collector] Done. ${results.length} source(s) processed.`);
+  const inserted = results.reduce((sum, r) => sum + (r.inserted || 0), 0);
+  const errors = results.filter(r => r.error).length;
+  console.log(`[collector] Total inserted: ${inserted}, errors: ${errors}`);
+}

--- a/src/collector.mjs
+++ b/src/collector.mjs
@@ -90,7 +90,7 @@ function httpGet(url, { timeout = 10000, maxBytes = 500000, redirectsLeft = 3 } 
         }
         let data = '';
         let size = 0;
-        resp.on('data', c => { size += c.length; if (size > maxBytes) { resp.destroy(); } else { data += c; } });
+        resp.on('data', c => { size += c.length; if (size > maxBytes) { resp.destroy(); clearTimeout(timer); reject(new Error('response too large')); } else { data += c; } });
         resp.on('end', () => { clearTimeout(timer); resolve({ status: resp.statusCode, contentType: resp.headers['content-type'] || '', body: data }); });
       } catch (e) { clearTimeout(timer); reject(e); }
     });

--- a/src/db.mjs
+++ b/src/db.mjs
@@ -532,12 +532,13 @@ export function recordSourceError(db, sourceId, errorMsg) {
 }
 
 export function getSourcesDueForFetch(db) {
+  // Only query types that have a fetcher implemented (skip twitter_* until Phase 1.5)
   return db.prepare(`
     SELECT * FROM sources
     WHERE is_active = 1 AND is_deleted = 0
+    AND type IN ('rss', 'digest_feed', 'hackernews', 'reddit', 'github_trending', 'website')
     AND (
       last_fetched_at IS NULL
-      OR (type IN ('twitter_feed', 'twitter_list', 'twitter_bookmarks') AND last_fetched_at < datetime('now', '-30 minutes'))
       OR (type IN ('hackernews', 'reddit') AND last_fetched_at < datetime('now', '-1 hour'))
       OR (type IN ('rss', 'website', 'digest_feed', 'github_trending') AND last_fetched_at < datetime('now', '-4 hours'))
     )

--- a/src/db.mjs
+++ b/src/db.mjs
@@ -102,6 +102,17 @@ export function getDb(dbPath) {
   } catch (e) {
     if (!e.message.includes('duplicate column')) console.error('Migration 009:', e.message);
   }
+  // Migration 010: raw_items table + sources error tracking
+  try {
+    const sql10 = readFileSync(join(ROOT, 'migrations', '010_raw_items.sql'), 'utf8');
+    for (const stmt of sql10.split(';').map(s => s.trim()).filter(Boolean)) {
+      try { _db.exec(stmt + ';'); } catch (e) {
+        if (!e.message.includes('duplicate column') && !e.message.includes('already exists')) throw e;
+      }
+    }
+  } catch (e) {
+    if (!e.message.includes('duplicate column') && !e.message.includes('already exists')) console.error('Migration 010:', e.message);
+  }
   // Backfill slugs for existing users
   _backfillSlugs(_db);
   return _db;
@@ -438,6 +449,100 @@ export function markFeedbackRead(db, id) {
 
 export function getUnreadFeedbackCount(db, userId) {
   return db.prepare("SELECT COUNT(*) as count FROM feedback WHERE user_id = ? AND reply IS NOT NULL AND read_at IS NULL").get(userId)?.count || 0;
+}
+
+// ── Raw Items ──
+
+export function insertRawItemsBatch(db, sourceId, items) {
+  const stmt = db.prepare(
+    'INSERT OR IGNORE INTO raw_items (source_id, title, url, author, content, published_at, dedup_key, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+  );
+  const run = db.transaction((rows) => {
+    let inserted = 0;
+    for (const item of rows) {
+      const key = item.dedupKey || (item.url ? `${sourceId}:${item.url}` : `${sourceId}:${_contentHash(item.content)}`);
+      const meta = typeof item.metadata === 'string' ? item.metadata : JSON.stringify(item.metadata || {});
+      const r = stmt.run(sourceId, item.title || '', item.url || '', item.author || '', item.content || '', item.publishedAt || null, key, meta);
+      inserted += r.changes;
+    }
+    return inserted;
+  });
+  return run(items);
+}
+
+function _contentHash(content) {
+  let h = 0;
+  const s = (content || '').slice(0, 500);
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+  }
+  return 'hash:' + (h >>> 0).toString(36);
+}
+
+export function listRawItems(db, { sourceId, since, limit = 100, offset = 0 } = {}) {
+  let sql = 'SELECT ri.*, s.name as source_name, s.type as source_type FROM raw_items ri JOIN sources s ON ri.source_id = s.id';
+  const conditions = [];
+  const params = [];
+  if (sourceId) { conditions.push('ri.source_id = ?'); params.push(sourceId); }
+  if (since) { conditions.push('ri.fetched_at >= ?'); params.push(since); }
+  if (conditions.length) sql += ' WHERE ' + conditions.join(' AND ');
+  sql += ' ORDER BY ri.fetched_at DESC LIMIT ? OFFSET ?';
+  params.push(Math.min(limit, 500), offset);
+  return db.prepare(sql).all(...params);
+}
+
+export function listRawItemsForDigest(db, sourceIds, { since, limit = 500 } = {}) {
+  if (!sourceIds.length) return [];
+  const placeholders = sourceIds.map(() => '?').join(',');
+  let sql = `SELECT ri.*, s.name as source_name, s.type as source_type FROM raw_items ri JOIN sources s ON ri.source_id = s.id WHERE ri.source_id IN (${placeholders})`;
+  const params = [...sourceIds];
+  if (since) { sql += ' AND ri.fetched_at >= ?'; params.push(since); }
+  sql += ' ORDER BY ri.fetched_at DESC LIMIT ?';
+  params.push(Math.min(limit, 1000));
+  return db.prepare(sql).all(...params);
+}
+
+export function getRawItemStats(db) {
+  return db.prepare(`
+    SELECT s.id as source_id, s.name, s.type,
+      COUNT(ri.id) as total_items,
+      MAX(ri.fetched_at) as last_item_at,
+      COUNT(CASE WHEN ri.fetched_at >= datetime('now', '-24 hours') THEN 1 END) as items_24h
+    FROM sources s
+    LEFT JOIN raw_items ri ON s.id = ri.source_id
+    WHERE s.is_active = 1 AND s.is_deleted = 0
+    GROUP BY s.id
+    ORDER BY last_item_at DESC NULLS LAST
+  `).all();
+}
+
+export function cleanOldRawItems(db, daysToKeep = 30) {
+  return db.prepare("DELETE FROM raw_items WHERE fetched_at < datetime('now', '-' || ? || ' days')").run(daysToKeep);
+}
+
+export function touchSourceFetch(db, sourceId) {
+  return db.prepare("UPDATE sources SET last_fetched_at = datetime('now'), fetch_count = fetch_count + 1, fetch_error_count = 0 WHERE id = ?").run(sourceId);
+}
+
+export function recordSourceError(db, sourceId, errorMsg) {
+  const lastError = JSON.stringify({ message: errorMsg, at: new Date().toISOString() });
+  db.prepare("UPDATE sources SET fetch_error_count = fetch_error_count + 1, last_error = ? WHERE id = ?").run(lastError, sourceId);
+  // Auto-pause after 5 consecutive failures
+  db.prepare("UPDATE sources SET is_active = 0 WHERE id = ? AND fetch_error_count >= 5").run(sourceId);
+}
+
+export function getSourcesDueForFetch(db) {
+  return db.prepare(`
+    SELECT * FROM sources
+    WHERE is_active = 1 AND is_deleted = 0
+    AND (
+      last_fetched_at IS NULL
+      OR (type IN ('twitter_feed', 'twitter_list', 'twitter_bookmarks') AND last_fetched_at < datetime('now', '-30 minutes'))
+      OR (type IN ('hackernews', 'reddit') AND last_fetched_at < datetime('now', '-1 hour'))
+      OR (type IN ('rss', 'website', 'digest_feed', 'github_trending') AND last_fetched_at < datetime('now', '-4 hours'))
+    )
+    ORDER BY last_fetched_at ASC NULLS FIRST
+  `).all();
 }
 
 // ── Config ──

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'url';
 import { randomBytes, createHmac, timingSafeEqual } from 'crypto';
 import { lookup } from 'dns/promises';
 import { isIP } from 'net';
-import { getDb, listDigests, getDigest, createDigest, listMarks, createMark, deleteMark, getConfig, setConfig, upsertUser, createSession, getSession, deleteSession, listSources, getSource, createSource, updateSource, deleteSource, getSourceByTypeConfig, getUserBySlug, listDigestsByUser, countDigestsByUser, createPack, getPack, getPackBySlug, listPacks, incrementPackInstall, deletePack, listSubscriptions, subscribe, unsubscribe, bulkSubscribe, isSubscribed, createFeedback, getUserFeedback, getAllFeedback, replyToFeedback, updateFeedbackStatus, markFeedbackRead, getUnreadFeedbackCount } from './db.mjs';
+import { getDb, listDigests, getDigest, createDigest, listMarks, createMark, deleteMark, getConfig, setConfig, upsertUser, createSession, getSession, deleteSession, listSources, getSource, createSource, updateSource, deleteSource, getSourceByTypeConfig, getUserBySlug, listDigestsByUser, countDigestsByUser, createPack, getPack, getPackBySlug, listPacks, incrementPackInstall, deletePack, listSubscriptions, subscribe, unsubscribe, bulkSubscribe, isSubscribed, createFeedback, getUserFeedback, getAllFeedback, replyToFeedback, updateFeedbackStatus, markFeedbackRead, getUnreadFeedbackCount, listRawItems, getRawItemStats, listRawItemsForDigest } from './db.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -819,6 +819,31 @@ const server = createServer(async (req, res) => {
       if (!validStatuses.includes(body.status)) return json(res, { error: 'invalid status' }, 400);
       updateFeedbackStatus(db, parseInt(feedbackStatusMatch[1]), body.status);
       return json(res, { ok: true });
+    }
+
+    // ── Raw Items endpoints ──
+
+    if (req.method === 'GET' && path === '/api/raw-items') {
+      if (!req.user) return json(res, { error: 'login required' }, 401);
+      const sourceId = params.get('source_id') ? parseInt(params.get('source_id')) : undefined;
+      const since = params.get('since') || undefined;
+      const limit = Math.min(parseInt(params.get('limit') || '50'), 200);
+      const offset = parseInt(params.get('offset') || '0');
+      return json(res, listRawItems(db, { sourceId, since, limit, offset }));
+    }
+
+    if (req.method === 'GET' && path === '/api/raw-items/stats') {
+      if (!req.user) return json(res, { error: 'login required' }, 401);
+      return json(res, getRawItemStats(db));
+    }
+
+    if (req.method === 'GET' && path === '/api/raw-items/for-digest') {
+      if (!req.user) return json(res, { error: 'login required' }, 401);
+      const subs = listSubscriptions(db, req.user.id);
+      const sourceIds = subs.filter(s => !s.is_deleted).map(s => s.id);
+      const since = params.get('since') || undefined;
+      const limit = Math.min(parseInt(params.get('limit') || '200'), 500);
+      return json(res, listRawItemsForDigest(db, sourceIds, { since, limit }));
     }
 
     // ── Config endpoints ──


### PR DESCRIPTION
## Summary

Implements the raw_items collection pipeline per merged PRD (PR #10).

- **Migration 010**: `raw_items` table + `fetch_error_count`/`last_error` columns on `sources`
- **Collector** (`src/collector.mjs`): independent process with fetchers for RSS, HN, Reddit, GitHub Trending, Website
- **Concurrency pool**: `COLLECTOR_CONCURRENCY` env (default 5), prevents overwhelming targets
- **Error tracking**: consecutive failures auto-pause source after 5 failures
- **SSRF protection**: private IP blocking, 10s timeout, 500KB max response
- **Dedup**: `UNIQUE(source_id, dedup_key)` + `INSERT OR IGNORE`
- **30-day TTL** cleanup on each collection cycle
- **3 API endpoints**: `/api/raw-items`, `/api/raw-items/stats`, `/api/raw-items/for-digest`
- **Scripts**: `npm run collect` / `npm run collect:loop`

Twitter sources left as Phase 1.5 TODO (needs API access — 90% of production sources).

## PRD Reference

`docs/prd/source-personalization.md` (merged in PR #10)

## Files Changed

| File | Change |
|------|--------|
| `migrations/010_raw_items.sql` | New: raw_items table + sources error columns |
| `src/collector.mjs` | New: collection pipeline + all fetchers |
| `src/db.mjs` | Add: raw_items CRUD + error tracking + fetch scheduling |
| `src/server.mjs` | Add: 3 API endpoints |
| `package.json` | Add: collect/collect:loop scripts |
| `.env.example` | Add: COLLECTOR_INTERVAL, COLLECTOR_CONCURRENCY, DEFAULT_SOURCE_ID |

## PRD Acceptance Criteria Coverage

- [x] 1. raw_items table via migration
- [x] 2. `npm run collect` fetches all active sources
- [x] 3. Dedup (INSERT OR IGNORE)
- [x] 4. RSS parsing (title, URL, content, pubdate)
- [x] 5. HN min_score filter + metadata
- [x] 6. Reddit subreddit posts
- [x] 7. GitHub Trending repos
- [x] 8. Website RSS autodiscovery + fallback
- [x] 9. SSRF protection
- [x] 10. /api/raw-items/stats
- [x] 11. /api/raw-items/for-digest (user subscription filter)
- [x] 12. 30-day TTL cleanup
- [ ] 13. Non-logged-in default digest (Phase 2 — needs digest generation integration)
- [ ] 14. New user auto-subscribe default source (Phase 2)
- [x] 15. Auto-pause after 5 consecutive failures
- [x] 16. Concurrency limit

## Test Plan

- [ ] Run migration on clean DB — verify raw_items table + sources columns created
- [ ] `npm run collect` with RSS source — verify items in raw_items
- [ ] Run collect twice — verify dedup (0 new inserts)
- [ ] Add HN source with min_score — verify score filtering
- [ ] Verify SSRF: source with localhost URL gets blocked
- [ ] Hit /api/raw-items/stats — verify JSON response
- [ ] Hit /api/raw-items/for-digest with subscribed user — verify filtering
- [ ] Verify auto-pause: artificially fail 5 times, confirm is_active=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)