### PR TITLE
fix: TG icon + clickable TG group link in info banner

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -186,7 +186,7 @@
   <div style="display:flex;justify-content:space-between;align-items:center;gap:12px;margin-bottom:8px;">
     <h1 style="margin:0;cursor:pointer" onclick="goHome()">☀️ ClawFeed</h1>
     <div style="display:flex;align-items:center;gap:8px;">
-      <a href="https://t.me/CocoAIxyz" target="_blank" rel="noopener" class="theme-toggle" title="Telegram" style="text-decoration:none;display:inline-flex;align-items:center;">✈️</a>
+      <a href="https://t.me/CocoAIxyz" target="_blank" rel="noopener" class="theme-toggle" title="Telegram" style="text-decoration:none;display:inline-flex;align-items:center;"><svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg></a>
       <button class="theme-toggle" id="themeToggle" onclick="toggleTheme()" title="Toggle theme">🌙</button>
       <div class="auth-bar" id="authBar"></div>
     </div>
@@ -300,7 +300,7 @@ const I18N = {
     feedbackTitle: '💬 反馈', feedbackPlaceholder: '说点什么...', feedbackEmailPlaceholder: '邮箱（可选）',
     feedbackSend: '发送', feedbackEmpty: '有什么想说的？我们会认真看每一条反馈 😊',
     feedbackSent: '✅ 已发送', feedbackNamePlaceholder: '名字（可选）',
-    infoBanner: '🔥 感谢大家热情！线上版本今天会快速迭代修掉一些 bug，进 TG 交流群保持更新',
+    infoBanner: '🔥 感谢大家热情！线上版本今天会快速迭代修掉一些 bug，进 <a href="https://t.me/CocoAIxyz" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:underline;">TG 交流群</a>保持更新',
   },
   en: {
     title: '☀️ ClawFeed',
@@ -361,7 +361,7 @@ const I18N = {
     feedbackTitle: '💬 Feedback', feedbackPlaceholder: 'Type your message...', feedbackEmailPlaceholder: 'Email (optional)',
     feedbackSend: 'Send', feedbackEmpty: 'Have something to say? We read every piece of feedback 😊',
     feedbackSent: '✅ Sent', feedbackNamePlaceholder: 'Name (optional)',
-    infoBanner: '🔥 Thanks for the enthusiasm! We\'re shipping bug fixes today — join our TG group for updates',
+    infoBanner: '🔥 Thanks for the enthusiasm! We\'re shipping bug fixes today — join our <a href="https://t.me/CocoAIxyz" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:underline;">TG group</a> for updates',
   }
 };
 
@@ -378,7 +378,7 @@ function setLang(l) {
 function applyLang() {
   document.querySelector('h1').textContent = t('title');
   document.getElementById('subtitleText').textContent = t('subtitle');
-  const ib = document.getElementById('infoBanner'); if (ib) ib.textContent = t('infoBanner');
+  const ib = document.getElementById('infoBanner'); if (ib) ib.innerHTML = t('infoBanner');
   const cl = document.getElementById('changelogLink'); if (cl) cl.textContent = t('changelog');
   document.querySelector('[data-type="4h"]').textContent = t('tab4h');
   document.querySelector('[data-type="daily"]').textContent = t('tabDaily');


### PR DESCRIPTION
## Summary
- Replace ✈️ emoji with proper Telegram SVG icon — the airplane was hard to recognize as Telegram
- Make "TG 交流群" / "TG group" text in the info banner a clickable link pointing to t.me/CocoAIxyz
- Switch info banner rendering from `textContent` to `innerHTML` to support the link

Fixes Kevin's feedback on PR #16.

## Test plan
- [ ] Verify Telegram icon is clearly recognizable in both light and dark themes
- [ ] Verify "TG group" / "TG 交流群" in info banner is clickable and opens t.me/CocoAIxyz
- [ ] Verify link styling (blue, underlined) is visible against the amber banner text

🤖 Generated with [Claude Code](https://claude.com/claude-code)