### PR TITLE
fix: subtitle @mentions link to Twitter profiles

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -191,7 +191,7 @@
       <div class="auth-bar" id="authBar"></div>
     </div>
   </div>
-  <p class="subtitle"><span id="subtitleText">AI news digest — powered by Lisa@OpenClaw, Jessie@Zylos</span></p>
+  <p class="subtitle" id="subtitleText">AI news digest — powered by <a href="https://x.com/ZylosAI" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-style:dotted;">Jessie@ZylosAI</a>, <a href="https://x.com/OpenClaw" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-style:dotted;">Lisa@OpenClaw</a></p>
   <p class="info-banner" id="infoBanner" style="color:#e8a838;font-size:0.85em;margin:-16px 0 16px 0;"></p>
   <div class="tabs">
     <div class="tab active" data-type="4h">4H 简报</div>
@@ -243,7 +243,7 @@ initTheme();
 const I18N = {
   zh: {
     title: '☀️ ClawFeed',
-    subtitle: 'AI 新闻简报 — powered by Lisa@OpenClaw, Jessie@Zylos',
+    subtitle: 'AI 新闻简报 — powered by <a href="https://x.com/ZylosAI" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-style:dotted;">Jessie@ZylosAI</a>, <a href="https://x.com/OpenClaw" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-style:dotted;">Lisa@OpenClaw</a>',
     tab4h: '4H 简报', tabDaily: '日报', tabWeekly: '周报', tabMonthly: '月报', tabMarks: '📌 Mark 收藏',
     loginBanner: '💡 登录 Google 账号即可收藏文章、管理个人书签',
     loginBtn: '登录', logout: '退出', signIn: '登录',
@@ -304,7 +304,7 @@ const I18N = {
   },
   en: {
     title: '☀️ ClawFeed',
-    subtitle: 'AI news digest — powered by Lisa@OpenClaw, Jessie@Zylos',
+    subtitle: 'AI news digest — powered by <a href="https://x.com/ZylosAI" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-style:dotted;">Jessie@ZylosAI</a>, <a href="https://x.com/OpenClaw" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-style:dotted;">Lisa@OpenClaw</a>',
     tab4h: '4H Briefs', tabDaily: 'Daily', tabWeekly: 'Weekly', tabMonthly: 'Monthly', tabMarks: '📌 Marks',
     loginBanner: '💡 Sign in with Google to bookmark articles and manage your reading list',
     loginBtn: 'Login', logout: 'Logout', signIn: 'Sign in',
@@ -377,7 +377,7 @@ function setLang(l) {
 
 function applyLang() {
   document.querySelector('h1').textContent = t('title');
-  document.getElementById('subtitleText').textContent = t('subtitle');
+  document.getElementById('subtitleText').innerHTML = t('subtitle');
   const ib = document.getElementById('infoBanner'); if (ib) ib.innerHTML = t('infoBanner');
   const cl = document.getElementById('changelogLink'); if (cl) cl.textContent = t('changelog');
   document.querySelector('[data-type="4h"]').textContent = t('tab4h');


### PR DESCRIPTION
## Summary
- Reorder subtitle: Jessie@ZylosAI first, Lisa@OpenClaw second
- Both @mentions are now clickable links to their Twitter profiles (x.com/ZylosAI, x.com/OpenClaw)
- Updated zh + en i18n strings
- Dotted underline style to indicate clickable without being distracting

## Test plan
- [ ] Click Jessie@ZylosAI → opens x.com/ZylosAI
- [ ] Click Lisa@OpenClaw → opens x.com/OpenClaw
- [ ] Links work in both zh and en language modes
- [ ] Link color inherits subtitle color in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)