### PR TITLE
chore: bump version to v0.8.1 + update changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.8.1 — 2026-02-24
+### ✨ New
+- **Telegram group link in info banner** — Clickable TG icon + group invite link with i18n support (#16)
+- **DEVOPLOG.md** — R&D lifecycle tracking for staging/production changes (#20)
+
+### 🔧 Fixed
+- **TG icon rendering** — Replace emoji with proper SVG icon, make TG group link clickable (#17)
+- **Subtitle Twitter links** — @mentions in subtitle now link to Twitter profiles (#18)
+- **ClawHub metadata alignment** — SKILL.md credentials declared, TESTING.md HttpOnly note, README/SKILL.md consistency (#25)
+
+### 🏗️ Infrastructure
+- **CI pipeline** — GitHub Actions for lint + security audit on PRs (#2, #9)
+- **PR template & CONTRIBUTING.md** — Standardized contribution workflow (#3)
+- **Health endpoint** — `GET /api/health` for CI readiness checks (#4)
+- **Feedback webhook config** — `FEEDBACK_LARK_WEBHOOK` in .env.example (#5)
+- **Dev process docs** — Full PROCESS.md workflow (#7)
+- **Security hardening** — SSRF protection, OAuth state validation, API key handling (#1)
+
 ## v0.7.0 — 2026-02-22
 ### ✨ New
 - **Dark/Light mode toggle** — Sun/moon toggle in header, persists in localStorage

--- a/CHANGELOG.zh.md
+++ b/CHANGELOG.zh.md
@@ -1,5 +1,31 @@
 # 更新日志
 
+## v0.8.1 — 2026-02-24
+### ✨ 新增
+- **Telegram 群组链接** — Info banner 增加可点击 TG 图标 + 群邀请链接，支持中英文 (#16)
+- **DEVOPLOG.md** — 研发全生命周期追踪（开发/staging/production）(#20)
+
+### 🔧 修复
+- **TG 图标渲染** — emoji 替换为 SVG 图标，群链接可点击 (#17)
+- **副标题 Twitter 链接** — @提及 现在链接到 Twitter 个人页 (#18)
+- **ClawHub 元数据对齐** — SKILL.md 凭证声明、TESTING.md HttpOnly 说明、README/SKILL.md 一致性 (#25)
+
+### 🏗️ 基础设施
+- **CI 流水线** — GitHub Actions lint + 安全审计 (#2, #9)
+- **PR 模板 & 贡献指南** — 标准化贡献流程 (#3)
+- **健康检查** — `GET /api/health` 端点 (#4)
+- **反馈 Webhook 配置** — .env.example 增加 `FEEDBACK_LARK_WEBHOOK` (#5)
+- **开发流程文档** — 完整 PROCESS.md 工作流 (#7)
+- **安全加固** — SSRF 防护、OAuth state 校验、API key 处理 (#1)
+
+## v0.7.0 — 2026-02-22
+### ✨ 新增
+- **深色/浅色模式切换** — Header 日/月图标，localStorage 持久化
+- **README 视频演示** — demo.mp4 作为 GitHub Release 资源嵌入
+
+### 🔧 修复
+- README 视频在 GitHub 上自动播放（Release 资源 URL 替代相对路径）
+
 ## v0.6.0 — 2026-02-22
 ### ✨ 新增
 - **Source 软删除** — 删除 Source 标记 `is_deleted` 而非硬删，避免 Pack 僵尸复活

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawfeed",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "description": "AI-powered news digest tool \u2014 generates structured summaries from Twitter/RSS feeds",
   "type": "module",
   "scripts": {

--- a/web/index.html
+++ b/web/index.html
@@ -489,7 +489,7 @@ function renderAuthBar() {
   const moreMenu = `<div class="user-menu" onclick="document.getElementById('moreDropdown').classList.toggle('show')">
     <span style="cursor:pointer;font-size:14px;color:#666;transition:color .2s;padding:2px 4px;" onmouseover="this.style.color='#ccc'" onmouseout="this.style.color='#666'">⋯</span>
     <div id="moreDropdown" class="user-dropdown">
-      <a href="https://github.com/kevinho/clawfeed" target="_blank" onclick="event.stopPropagation();">${ghSvg} GitHub <span style="color:#555;font-size:12px;">v0.7.0</span></a>
+      <a href="https://github.com/kevinho/clawfeed" target="_blank" onclick="event.stopPropagation();">${ghSvg} GitHub <span style="color:#555;font-size:12px;">v0.8.1</span></a>
       <a href="#" onclick="event.stopPropagation();showChangelog();return false;">📋 ${t('changelog')}</a>
       <a href="#" onclick="event.stopPropagation();showRoadmap();return false;">🗺️ ${t('roadmap')}</a>
     </div>


### PR DESCRIPTION
## Summary
- Bump `package.json` version from 0.7.0 → 0.8.1
- Update version display in `web/index.html`
- Add v0.8.1 entry to `CHANGELOG.md` and `CHANGELOG.zh.md`

Prepares for ClawHub v0.8.1 publish. After merge, Lisa will run `clawhub publish`.

## Test plan
- [ ] Version shows 0.8.1 in package.json
- [ ] Version shows v0.8.1 in web UI (More → GitHub link)
- [ ] CHANGELOG entries match merged PRs #1-#5, #7, #9, #16-#18, #20, #25