### PR TITLE
fix: colored subtitle agent names

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -191,7 +191,7 @@
       <div class="auth-bar" id="authBar"></div>
     </div>
   </div>
-  <p class="subtitle" id="subtitleText">AI news digest — powered by <a href="https://x.com/ZylosAI" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-style:dotted;">Jessie@ZylosAI</a>, <a href="https://x.com/OpenClaw" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-style:dotted;">Lisa@OpenClaw</a></p>
+  <p class="subtitle" id="subtitleText">AI news digest — powered by <a href="https://x.com/ZylosAI" target="_blank" rel="noopener" style="color:#6CB4EE;text-decoration:underline;text-decoration-style:dotted;">Jessie@ZylosAI</a>, <a href="https://x.com/OpenClaw" target="_blank" rel="noopener" style="color:#7CD992;text-decoration:underline;text-decoration-style:dotted;">Lisa@OpenClaw</a></p>
   <p class="info-banner" id="infoBanner" style="color:#e8a838;font-size:0.85em;margin:-16px 0 16px 0;"></p>
   <div class="tabs">
     <div class="tab active" data-type="4h">4H 简报</div>
@@ -243,7 +243,7 @@ initTheme();
 const I18N = {
   zh: {
     title: '☀️ ClawFeed',
-    subtitle: 'AI 新闻简报 — powered by <a href="https://x.com/ZylosAI" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-style:dotted;">Jessie@ZylosAI</a>, <a href="https://x.com/OpenClaw" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-style:dotted;">Lisa@OpenClaw</a>',
+    subtitle: 'AI 新闻简报 — powered by <a href="https://x.com/ZylosAI" target="_blank" rel="noopener" style="color:#6CB4EE;text-decoration:underline;text-decoration-style:dotted;">Jessie@ZylosAI</a>, <a href="https://x.com/OpenClaw" target="_blank" rel="noopener" style="color:#7CD992;text-decoration:underline;text-decoration-style:dotted;">Lisa@OpenClaw</a>',
     tab4h: '4H 简报', tabDaily: '日报', tabWeekly: '周报', tabMonthly: '月报', tabMarks: '📌 Mark 收藏',
     loginBanner: '💡 登录 Google 账号即可收藏文章、管理个人书签',
     loginBtn: '登录', logout: '退出', signIn: '登录',
@@ -304,7 +304,7 @@ const I18N = {
   },
   en: {
     title: '☀️ ClawFeed',
-    subtitle: 'AI news digest — powered by <a href="https://x.com/ZylosAI" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-style:dotted;">Jessie@ZylosAI</a>, <a href="https://x.com/OpenClaw" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline;text-decoration-style:dotted;">Lisa@OpenClaw</a>',
+    subtitle: 'AI news digest — powered by <a href="https://x.com/ZylosAI" target="_blank" rel="noopener" style="color:#6CB4EE;text-decoration:underline;text-decoration-style:dotted;">Jessie@ZylosAI</a>, <a href="https://x.com/OpenClaw" target="_blank" rel="noopener" style="color:#7CD992;text-decoration:underline;text-decoration-style:dotted;">Lisa@OpenClaw</a>',
     tab4h: '4H Briefs', tabDaily: 'Daily', tabWeekly: 'Weekly', tabMonthly: 'Monthly', tabMarks: '📌 Marks',
     loginBanner: '💡 Sign in with Google to bookmark articles and manage your reading list',
     loginBtn: 'Login', logout: 'Logout', signIn: 'Sign in',


### PR DESCRIPTION
## Summary
- Jessie@ZylosAI: blue (#6CB4EE)
- Lisa@OpenClaw: green (#7CD992)
- Applied to HTML default + zh/en i18n strings

Per Kevin's request to highlight agent names in the subtitle.

## Test plan
- [ ] Dark mode: both colors readable against dark background
- [ ] Light mode: both colors readable against light background
- [ ] Language toggle: colors persist in both zh/en