### PR TITLE
feature: add docker run support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Dependencies (rebuilt in container)
+node_modules/
+
+# Git
+.git/
+.gitignore
+
+# Data and databases
+data/
+*.db
+*.db-journal
+*.db-wal
+
+# Environment and secrets
+.env
+.env.*
+!.env.example
+
+# Development and testing
+test/
+demo-assets/
+docs/
+
+# CI/CD
+.github/
+
+# IDE and editor
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - 'release/**'
-      - 'devel/**'
       - 'dev/**'
     tags:
       - 'v*'
@@ -22,8 +21,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Determine Docker Tags
         id: docker_tags

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,65 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+      - 'devel/**'
+      - 'dev/**'
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+  USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine Docker Tags
+        id: docker_tags
+        run: |
+          TAGS=""
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAG_VERSION=${GITHUB_REF#refs/tags/}
+            TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG_VERSION},${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+            echo "Building release: $TAG_VERSION"
+          else
+            TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:devel"
+            echo "Building development version"
+          fi
+          echo "TAGS=$TAGS" >> $GITHUB_OUTPUT
+          echo "Docker tags: $TAGS"
+
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.USERNAME }}
+          password: ${{ env.TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_tags.outputs.TAGS }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:20-alpine
+# Build stage
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 
@@ -17,13 +18,28 @@ COPY migrations/ ./migrations/
 COPY templates/ ./templates/
 COPY web/ ./web/
 
-# Create data directory
-RUN mkdir -p /app/data
+# Production stage
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Copy built artifacts from builder
+COPY --from=builder /app ./
+
+# Create data directory and set ownership
+RUN mkdir -p /app/data && chown -R node:node /app
+
+# Use non-root user
+USER node
 
 ENV NODE_ENV=production
 ENV DIGEST_PORT=8767
 ENV DIGEST_HOST=0.0.0.0
 
 EXPOSE 8767
+
+# Health check for orchestration environments
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -q --spider http://localhost:8767/ || exit 1
 
 CMD ["node", "src/server.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install build dependencies for better-sqlite3
+RUN apk add --no-cache python3 make g++
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci --only=production
+
+# Copy source code
+COPY src/ ./src/
+COPY migrations/ ./migrations/
+COPY templates/ ./templates/
+COPY web/ ./web/
+
+# Create data directory
+RUN mkdir -p /app/data
+
+ENV NODE_ENV=production
+ENV DIGEST_PORT=8767
+
+EXPOSE 8767
+
+CMD ["node", "src/server.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir -p /app/data
 
 ENV NODE_ENV=production
 ENV DIGEST_PORT=8767
+ENV DIGEST_HOST=0.0.0.0
 
 EXPOSE 8767
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ cd clawfeed
 npm install
 ```
 
+### Option 5: Docker
+```bash
+docker run -d -p 8767:8767 songtianlun/clawfeed
+docker run -d -p 8767:8767 -v clawfeed-data:/app/data songtianlun/clawfeed
+```
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -61,8 +61,21 @@ npm install
 
 ### Option 5: Docker
 ```bash
-docker run -d -p 8767:8767 songtianlun/clawfeed
-docker run -d -p 8767:8767 -v clawfeed-data:/app/data songtianlun/clawfeed
+# Basic usage
+docker run -d -p 8767:8767 kevinho/clawfeed
+
+# With persistent data
+docker run -d -p 8767:8767 -v clawfeed-data:/app/data kevinho/clawfeed
+
+# With environment variables (recommended for production)
+docker run -d -p 8767:8767 \
+  -v clawfeed-data:/app/data \
+  -e ALLOWED_ORIGINS=https://yourdomain.com \
+  -e API_KEY=your-api-key \
+  -e GOOGLE_CLIENT_ID=your-client-id \
+  -e GOOGLE_CLIENT_SECRET=your-client-secret \
+  -e SESSION_SECRET=your-session-secret \
+  kevinho/clawfeed
 ```
 
 ## Quick Start

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -864,6 +864,7 @@ const server = createServer(async (req, res) => {
   }
 });
 
-server.listen(PORT, '127.0.0.1', () => {
-  console.log(`🚀 ClawFeed API running on http://127.0.0.1:${PORT}`);
+const HOST = process.env.DIGEST_HOST || '127.0.0.1';
+server.listen(PORT, HOST, () => {
+  console.log(`🚀 ClawFeed API running on http://${HOST}:${PORT}`);
 });


### PR DESCRIPTION
##  需求理解 / Requirement Understanding

**我理解的需求是：**
为ClawFeed 项目添加 Docker 容器化支持，包括 Dockerfile、GitHub Action 自动构建工作流，以及在 README中添加容器化运行说明。

**原始指令/Issue：**
参考 Diaria 项目的 docker-build.yml 实现容器化运行能力

---
## Summary

- 新增 Dockerfile，基于 Node.js 20 Alpine，支持 better-sqlite3 原生编译
- 新增 GitHub Action 工作流，支持多架构构建（amd64/arm64）并自动推送到 Docker Hub
- 修改服务器监听地址支持 DIGEST_HOST 环境变量，解决容器内网络访问问题
- 更新 README 添加 Docker 运行说明

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] CI / DevOps
- [ ] Docs

## Test plan

- npm test passes
- npm run lint passes
- Manual verification: 本地 docker build 并运行容器，验证端口映射可正常访问服务

Checklist
- [x] No secrets or credentials committed
- [x] No `console.log` left in production code
- [x] Breaking changes documented (if any)